### PR TITLE
Bugfix queue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "io.r_a_d.radio2"
         minSdkVersion 16
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1dev"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/io/r_a_d/radio2/playerstore/PlayerStore.kt
+++ b/app/src/main/java/io/r_a_d/radio2/playerstore/PlayerStore.kt
@@ -159,11 +159,13 @@ class PlayerStore : ViewModel() {
             val result = JSONObject(it as String)
             if (result.has("main")) {
                 val resMain = result.getJSONObject("main")
-                if (resMain.has("requesting") && !resMain.getBoolean("requesting") && queue.isNotEmpty())
+                if ((resMain.has("isafkstream") && !resMain.getBoolean("isafkstream")) &&
+                    queue.isNotEmpty())
                 {
                     queue.clear() //we're not requesting anything anymore.
                     isQueueUpdated.value = true
-                } else if (resMain.has("requesting") && resMain.getBoolean("requesting") && queue.isEmpty())
+                } else if (resMain.has("isafkstream") && resMain.getBoolean("isafkstream") &&
+                            queue.isEmpty())
                 {
                     initApi()
                 } else if (resMain.has("queue")) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.60'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Should fix:

- last queued song fetch that could be the same as second-to-last (if it's the same, retry a bit later)
- when a non-afk streamer is up, should stop fetching the last queued song (relying on field **isafkstreamer** instead of **requesting**).

Changes to be merged into devel, where other bigfixes and adjustments can be made later.